### PR TITLE
Surface object-scripting completion errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ releases use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   metacharacters on Windows.
 - Return asynchronous installation and configuration failures through the
   `setup()` callback instead of only displaying an error notification.
+- Wait for SQL Tools Service object-scripting completion so failed or empty
+  definition scripts report an error instead of opening a definition buffer.
 
 ## [1.0.0-rc.3] - 2026-09-09
 

--- a/lua/sqlserver/adapters/sql_tools_service/scripting.lua
+++ b/lua/sqlserver/adapters/sql_tools_service/scripting.lua
@@ -1,0 +1,64 @@
+local utils = require("sqlserver.utils")
+
+local M = {}
+
+---@param client vim.lsp.Client
+---@param params table
+---@param timeout integer|false
+---@return table
+function M.script_async(client, params, timeout)
+  local completions = {}
+  local waiting
+  local waiting_operation_id
+  local handler
+  handler = function(err, result)
+    if result and result.operationId then
+      completions[result.operationId] = { result = result, error = err }
+      if waiting and result.operationId == waiting_operation_id and coroutine.status(waiting) == "suspended" then
+        utils.try_resume(waiting)
+      end
+    end
+    return result, err
+  end
+  utils.register_lsp_handler(client, "scripting/scriptComplete", handler)
+
+  local response, request_error = utils.lsp_request_async(client, "scripting/script", params)
+  if request_error then
+    utils.unregister_lsp_handler(client, "scripting/scriptComplete", handler)
+    error("SQL Tools Service could not script the selected object: " .. request_error.message, 0)
+  end
+  if not (response and response.operationId) then
+    utils.unregister_lsp_handler(client, "scripting/scriptComplete", handler)
+    error("SQL Tools Service returned an invalid scripting response", 0)
+  end
+
+  local completion = completions[response.operationId]
+  if not completion then
+    waiting = coroutine.running()
+    waiting_operation_id = response.operationId
+    if timeout then
+      vim.defer_fn(function()
+        if not completions[waiting_operation_id] and waiting and coroutine.status(waiting) == "suspended" then
+          utils.try_resume(waiting)
+        end
+      end, timeout)
+    end
+    coroutine.yield()
+    completion = completions[response.operationId]
+  end
+  utils.unregister_lsp_handler(client, "scripting/scriptComplete", handler)
+
+  if not completion then
+    error("SQL Tools Service did not complete the scripting operation", 0)
+  end
+  if completion.error then
+    error("SQL Tools Service could not script the selected object: " .. completion.error.message, 0)
+  end
+  if completion.result.hasError or completion.result.success == false then
+    local message = completion.result.errorMessage or "The scripting operation failed"
+    error("SQL Tools Service could not script the selected object: " .. message, 0)
+  end
+  return response
+end
+
+return M

--- a/lua/sqlserver/objects/script.lua
+++ b/lua/sqlserver/objects/script.lua
@@ -30,4 +30,19 @@ function M.supported_types()
   return vim.tbl_keys(definition_specs)
 end
 
+---@param response table?
+---@param intent "query"|"definition"
+---@return string
+function M.response_text(response, intent)
+  if not (response and type(response.script) == "string") then
+    error("Error generating script (no script returned from language server)", 0)
+  end
+
+  local script = response.script:gsub("\r", "")
+  if intent == "definition" and not script:find("%S") then
+    error("SQL Tools Service returned no object definition", 0)
+  end
+  return script
+end
+
 return M

--- a/lua/sqlserver/objects/ui/picker.lua
+++ b/lua/sqlserver/objects/ui/picker.lua
@@ -1,5 +1,6 @@
 local utils = require("sqlserver.utils")
 local object_script = require("sqlserver.objects.script")
+local scripting = require("sqlserver.adapters.sql_tools_service.scripting")
 local object_explorer_timeout = 10000
 
 ---Same as utils.wait_for_notification_async but ignores any owner uri
@@ -270,18 +271,10 @@ local generate_script_async = function(item, client, owner_uri, intent)
     ownerURI = owner_uri,
     operation = spec.operation,
   }
-  local res, script_err = utils.lsp_request_async(client, "scripting/script", scripting_params)
-  if script_err then
-    error("SQL Tools Service could not script the selected object: " .. script_err.message, 0)
-  end
-
-  if not (res and res.script) then
-    error("Error generating script (no script returned from language server)", 0)
-  end
+  local res = scripting.script_async(client, scripting_params, object_explorer_timeout)
 
   return {
-    -- strip carriage returns
-    script = res.script:gsub("\r", ""),
+    script = object_script.response_text(res, intent),
     execute_immediately = spec.execute_immediately == true,
     object = public_object(item),
   }

--- a/tests/helpers/integration.lua
+++ b/tests/helpers/integration.lua
@@ -52,7 +52,7 @@ function M.new_query_buffer()
   return bufnr
 end
 
-function M.connect(bufnr, database)
+function M.connect_with(bufnr, options)
   local connection
   local ready
   local ready_error
@@ -61,11 +61,11 @@ function M.connect(bufnr, database)
     function()
       connection = M.await(function(callback)
         require("sqlserver").connect({
-          server = vim.env.DbServer,
-          database = database or vim.env.DbDatabase,
+          server = options.server or vim.env.DbServer,
+          database = options.database or vim.env.DbDatabase,
           authenticationType = "SqlLogin",
-          user = vim.env.DbUser,
-          password = vim.env.DbPassword,
+          user = options.user,
+          password = options.password,
           trustServerCertificate = true,
         }, { bufnr = bufnr }, callback)
       end)
@@ -77,6 +77,14 @@ function M.connect(bufnr, database)
   assert(not ready_error, ready_error and ready_error.message)
   assert(ready, "SQL Tools Service did not report that IntelliSense was ready")
   return connection
+end
+
+function M.connect(bufnr, database)
+  return M.connect_with(bufnr, {
+    database = database,
+    user = vim.env.DbUser,
+    password = vim.env.DbPassword,
+  })
 end
 
 function M.cleanup()

--- a/tests/integration/seed.sql
+++ b/tests/integration/seed.sql
@@ -11,6 +11,9 @@ BEGIN
   DROP DATABASE TestDbB;
 END;
 GO
+IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'sqlserver_nvim_restricted')
+  DROP LOGIN sqlserver_nvim_restricted;
+GO
 
 CREATE DATABASE TestDbA;
 GO
@@ -87,4 +90,14 @@ RETURN
   FROM dbo.Car
   WHERE PersonId = @PersonID
 );
+GO
+USE master;
+CREATE LOGIN sqlserver_nvim_restricted
+  WITH PASSWORD = 'Restricted_Password_123';
+GO
+USE TestDbB;
+CREATE USER sqlserver_nvim_restricted
+  FOR LOGIN sqlserver_nvim_restricted;
+GRANT SELECT ON OBJECT::dbo.Car TO sqlserver_nvim_restricted;
+GRANT VIEW DEFINITION ON OBJECT::dbo.Car TO sqlserver_nvim_restricted;
 GO

--- a/tests/integration/specs/object_scripting_spec.lua
+++ b/tests/integration/specs/object_scripting_spec.lua
@@ -32,6 +32,13 @@ local function run_action_async(action)
   return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n"), bufnr
 end
 
+local function execute_async(bufnr, text)
+  local execution = test_utils.await(function(callback)
+    sqlserver.execute({ bufnr = bufnr, text = text }, callback)
+  end)
+  execution.dispose()
+end
+
 local T = MiniTest.new_set()
 
 T["Object actions should build queries and definitions"] = require("tests.helpers").async(function()
@@ -90,6 +97,59 @@ T["Object actions should build queries and definitions"] = require("tests.helper
   assert(vim.fn.fnamemodify(vim.api.nvim_buf_get_name(duplicate_definition), ":t") == "dbo.CarView (2).sql")
   vim.api.nvim_buf_delete(original_definition, { force = true })
   vim.api.nvim_buf_delete(duplicate_definition, { force = true })
+end)
+
+T["Object definitions should surface SQL Tools Service errors"] = require("tests.helpers").async(function()
+  local admin_bufnr = vim.api.nvim_get_current_buf()
+  test_utils.await(function(callback)
+    sqlserver.disconnect(admin_bufnr, callback)
+  end)
+  test_utils.connect(admin_bufnr, "TestDbB")
+
+  local restricted_bufnr = test_utils.new_query_buffer()
+  test_utils.connect_with(restricted_bufnr, {
+    database = "TestDbB",
+    user = "sqlserver_nvim_restricted",
+    password = "Restricted_Password_123",
+  })
+
+  execute_async(admin_bufnr, "DENY VIEW DEFINITION ON OBJECT::dbo.Car TO sqlserver_nvim_restricted;")
+
+  local original_notify = vim.notify
+  local notification
+  vim.notify = function(message, level, opts)
+    if message:find("could not script the selected object", 1, true) then
+      notification = { message = message, level = level }
+      return
+    end
+    return original_notify(message, level, opts)
+  end
+
+  local ok, failure = xpcall(function()
+    vim.api.nvim_set_current_buf(restricted_bufnr)
+    select_object("Table", "Car")
+    local buffers_before = #vim.api.nvim_list_bufs()
+    local completed = false
+    sqlserver.show_object_definition(function()
+      completed = true
+    end)
+
+    assert(
+      vim.wait(30000, function()
+        return notification ~= nil
+      end, 10),
+      "Object scripting failure was not presented"
+    )
+    assert(notification.level == vim.log.levels.ERROR)
+    assert(notification.message:find("An error occurred while scripting the objects", 1, true))
+    assert(not completed, "Failed object scripting must not report success")
+    assert(vim.api.nvim_get_current_buf() == restricted_bufnr, "Failed object scripting changed the current buffer")
+    assert(#vim.api.nvim_list_bufs() == buffers_before, "Failed object scripting opened a definition buffer")
+  end, debug.traceback)
+
+  vim.notify = original_notify
+  execute_async(admin_bufnr, "GRANT VIEW DEFINITION ON OBJECT::dbo.Car TO sqlserver_nvim_restricted;")
+  assert(ok, failure)
 end)
 
 return T

--- a/tests/unit/object_script_spec.lua
+++ b/tests/unit/object_script_spec.lua
@@ -35,4 +35,28 @@ T["Object scripting should separate queries from definitions"] = require("tests.
   assert(not valid and err:find("Unsupported", 1, true))
 end)
 
+T["Object scripting should reject empty definitions"] = function()
+  for _, script in ipairs({ "", " \n\t\r\n" }) do
+    local valid, err = pcall(object_script.response_text, { script = script }, "definition")
+    assert(not valid)
+    assert(err:find("returned no object definition", 1, true))
+  end
+end
+
+T["Object scripting should normalize returned scripts"] = function()
+  assert(object_script.response_text({ script = "SELECT 1\r\n" }, "query") == "SELECT 1\n")
+  assert(
+    object_script.response_text({ script = "CREATE VIEW dbo.Cars AS\r\nSELECT 1" }, "definition")
+      == "CREATE VIEW dbo.Cars AS\nSELECT 1"
+  )
+end
+
+T["Object scripting should reject missing scripts"] = function()
+  for _, response in ipairs({ false, {}, { script = vim.NIL } }) do
+    local valid, err = pcall(object_script.response_text, response, "definition")
+    assert(not valid)
+    assert(err:find("no script returned", 1, true))
+  end
+end
+
 return T

--- a/tests/unit/sql_tools_service_scripting_spec.lua
+++ b/tests/unit/sql_tools_service_scripting_spec.lua
@@ -1,0 +1,75 @@
+local scripting = require("sqlserver.adapters.sql_tools_service.scripting")
+
+local function fake_client(response, completion, request_error, completion_after_response)
+  local client = { handlers = {} }
+  client.request = function(_, method, _, callback)
+    assert(method == "scripting/script")
+    vim.schedule(function()
+      if completion and not completion_after_response then
+        client.handlers["scripting/scriptComplete"](nil, completion)
+      end
+      callback(request_error, response)
+      if completion and completion_after_response then
+        vim.schedule(function()
+          client.handlers["scripting/scriptComplete"](nil, completion)
+        end)
+      end
+    end)
+  end
+  return client
+end
+
+local T = MiniTest.new_set()
+
+T["Scripting should correlate completion sent before the response"] = require("tests.helpers").async(function()
+  local response = { operationId = "before", script = "CREATE TABLE dbo.Car (ID int)" }
+  local result = scripting.script_async(
+    fake_client(response, {
+      operationId = "before",
+      success = true,
+      hasError = false,
+    }),
+    {},
+    100
+  )
+  assert(result == response)
+end)
+
+T["Scripting should wait for completion sent after the response"] = require("tests.helpers").async(function()
+  local response = { operationId = "after", script = "CREATE VIEW dbo.CarView AS SELECT 1" }
+  local result = scripting.script_async(
+    fake_client(response, {
+      operationId = "after",
+      success = true,
+      hasError = false,
+    }, nil, true),
+    {},
+    100
+  )
+  assert(result == response)
+end)
+
+T["Scripting should surface completion errors"] = require("tests.helpers").async(function()
+  local response = { operationId = "failed" }
+  local valid, err = pcall(
+    scripting.script_async,
+    fake_client(response, {
+      operationId = "failed",
+      success = false,
+      hasError = true,
+      errorMessage = "An error occurred while scripting the objects.",
+    }),
+    {},
+    100
+  )
+  assert(not valid)
+  assert(err:find("An error occurred while scripting the objects", 1, true))
+end)
+
+T["Scripting should reject missing completion notifications"] = require("tests.helpers").async(function()
+  local valid, err = pcall(scripting.script_async, fake_client({ operationId = "missing" }), {}, 10)
+  assert(not valid)
+  assert(err:find("did not complete", 1, true))
+end)
+
+return T

--- a/tests/unit/test_unit.lua
+++ b/tests/unit/test_unit.lua
@@ -24,6 +24,7 @@ local modules = {
   "result_sticky_header_spec",
   "query_selection_spec",
   "sql_tools_service_query_spec",
+  "sql_tools_service_scripting_spec",
   "query_summary_spec",
   "object_script_spec",
 }


### PR DESCRIPTION
## Proposed changes

Wait for SQL Tools Service object-scripting completion notifications and correlate them with the originating request so asynchronous failures are reported before a definition buffer opens. Reject missing or empty scripts as a fallback for malformed service responses.

Add unit coverage for both notification orderings and Docker-backed coverage using a restricted login whose object-definition permission is revoked after discovery. Failed scripting must notify the user, leave the current buffer unchanged, and avoid opening an empty definition buffer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring or internal improvement
- [ ] Documentation

## Checklist

- [x] I have read the [contributing guide](https://github.com/NicholasMata/sqlserver.nvim/blob/main/CONTRIBUTING.md).
- [x] This pull request contains one coherent change.
- [x] I have added or updated relevant tests, or explained why none are needed.
- [x] I have updated relevant documentation, or none is needed.
- [x] I have updated the Unreleased changelog, or the change is not user-visible.
- [x] I have not included credentials or private database contents.

## Further context

SQL Tools Service returns an initial scripting response separately from its completion notification. The completion notification can arrive before or after the response, so the adapter retains and correlates both orderings before reporting success or failure.