### PR TITLE
fix(installer): edit `run_async` call for installing tools on Windows

### DIFF
--- a/lua/sqlserver/adapters/sql_tools_service/installer.lua
+++ b/lua/sqlserver/adapters/sql_tools_service/installer.lua
@@ -87,8 +87,10 @@ function M.download_tools_async(release, data_folder)
       "powershell",
       "-NoProfile",
       "-Command",
-      "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri $args[0] -OutFile $args[1]",
+      "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest",
+      "-Uri",
       release.url,
+      "-OutFile",
       archive,
     })
   else
@@ -106,8 +108,10 @@ function M.download_tools_async(release, data_folder)
       "powershell",
       "-NoProfile",
       "-Command",
-      "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1]",
+      "Expand-Archive",
+      "-LiteralPath",
       archive,
+      "-DestinationPath",
       staging,
     })
   else


### PR DESCRIPTION
Fixes `run_async` call for `download` and `extract` variables to download and install the SQL Tools Service for Windows OS (Powershell). Tested on two Windows PC with Powershell version 5.1.

_p.s.: first time submitting a PR to an OSS repo, kindly let me know if I missed something. Thanks :)_

