### PR TITLE
Handle special characters in installer paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ releases use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Pass download and extraction arguments correctly to PowerShell so managed
-  SQL Tools Service installation works on Windows.
+- Pass download and extraction values through PowerShell environment variables
+  so managed SQL Tools Service installation supports paths containing shell
+  metacharacters on Windows.
 - Return asynchronous installation and configuration failures through the
   `setup()` callback instead of only displaying an error notification.
 

--- a/lua/sqlserver/adapters/sql_tools_service/installer.lua
+++ b/lua/sqlserver/adapters/sql_tools_service/installer.lua
@@ -36,14 +36,19 @@ function M.get_tools_download_url()
   return M.get_release().url
 end
 
-local function run_async(command)
+local function run_async(command, opts)
   local co = coroutine.running()
-  vim.system(command, { text = true }, function(result)
+  opts = vim.tbl_extend("force", { text = true }, opts or {})
+  vim.system(command, opts, function(result)
     vim.schedule(function()
       utils.try_resume(co, result)
     end)
   end)
   return coroutine.yield()
+end
+
+local function run_powershell_async(script, env)
+  return run_async({ "powershell", "-NoProfile", "-Command", script }, { env = env })
 end
 
 local function remove(path)
@@ -83,16 +88,15 @@ function M.download_tools_async(release, data_folder)
 
   local download
   if jit.os == "Windows" then
-    download = run_async({
-      "powershell",
-      "-NoProfile",
-      "-Command",
-      "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest",
-      "-Uri",
-      release.url,
-      "-OutFile",
-      archive,
-    })
+    download = run_powershell_async(
+      "$ProgressPreference='SilentlyContinue'; "
+        .. "Invoke-WebRequest -Uri $env:SQLSERVER_NVIM_DOWNLOAD_URI "
+        .. "-OutFile $env:SQLSERVER_NVIM_DOWNLOAD_ARCHIVE",
+      {
+        SQLSERVER_NVIM_DOWNLOAD_URI = release.url,
+        SQLSERVER_NVIM_DOWNLOAD_ARCHIVE = archive,
+      }
+    )
   else
     download = run_async({ "curl", "-fsSL", release.url, "-o", archive })
   end
@@ -104,16 +108,14 @@ function M.download_tools_async(release, data_folder)
 
   local extract
   if jit.os == "Windows" then
-    extract = run_async({
-      "powershell",
-      "-NoProfile",
-      "-Command",
-      "Expand-Archive",
-      "-LiteralPath",
-      archive,
-      "-DestinationPath",
-      staging,
-    })
+    extract = run_powershell_async(
+      "Expand-Archive -LiteralPath $env:SQLSERVER_NVIM_DOWNLOAD_ARCHIVE "
+        .. "-DestinationPath $env:SQLSERVER_NVIM_INSTALL_STAGING",
+      {
+        SQLSERVER_NVIM_DOWNLOAD_ARCHIVE = archive,
+        SQLSERVER_NVIM_INSTALL_STAGING = staging,
+      }
+    )
   else
     extract = run_async({ "tar", "-xzf", archive, "-C", staging })
   end

--- a/tests/platform/test_platform.lua
+++ b/tests/platform/test_platform.lua
@@ -10,8 +10,11 @@ local T = MiniTest.new_set({
   },
 })
 
-T["managed SQL Tools Service installs and starts"] = helpers.async(function()
-  local data_dir = vim.fn.tempname()
+T["managed SQL Tools Service installs from special-character paths"] = helpers.async(function()
+  -- PowerShell treats spaces and ampersands as syntax when native command
+  -- arguments are not preserved correctly. Exercise both the download archive
+  -- and extraction destination with a path that requires proper quoting.
+  local data_dir = vim.fn.tempname() .. " sqlserver.nvim & installer"
   local setup_complete = false
   local setup_error
   local stop_error


### PR DESCRIPTION
## Proposed changes

Run the native SQL Tools Service lifecycle test from an installation path containing spaces and a shell-significant ampersand on every supported platform.

On Windows, pass dynamic download and extraction values through the child PowerShell process environment. This prevents valid path metacharacters from being parsed as PowerShell command syntax while leaving the direct argument handling on Linux and macOS unchanged.

Keep command execution generic and contain the PowerShell-specific value transport in a dedicated helper.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring or internal improvement
- [ ] Documentation

## Checklist

- [x] I have read the [contributing guide](https://github.com/NicholasMata/sqlserver.nvim/blob/main/CONTRIBUTING.md).
- [x] This pull request contains one coherent change.
- [x] I have added or updated relevant tests, or explained why none are needed.
- [x] I have updated relevant documentation, or none is needed.
- [x] I have updated the Unreleased changelog, or the change is not user-visible.
- [x] I have not included credentials or private database contents.

## Further context

The regression test downloads, extracts, starts, attaches to, and stops the real platform-specific SQL Tools Service package. It reproduces the Windows failure observed after #2 when the installation path contains `&`, while continuing to exercise the same lifecycle on Linux and macOS.