### PR TITLE
Refresh object metadata from the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ releases use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `setup()` callback instead of only displaying an error notification.
 - Wait for SQL Tools Service object-scripting completion so failed or empty
   definition scripts report an error instead of opening a definition buffer.
+- Refresh Object Explorer metadata from the server so explicit refreshes
+  reflect schema and permission changes without retaining stale cache data.
 
 ## [1.0.0-rc.3] - 2026-09-09
 

--- a/lua/sqlserver/objects/ui/picker.lua
+++ b/lua/sqlserver/objects/ui/picker.lua
@@ -120,7 +120,7 @@ local function is_object_branch(node_path, database_path)
   end)
 end
 
-local get_object_cache_async = function(lsp_client, connection_options, cancellation_token)
+local get_object_cache_async = function(lsp_client, connection_options, cancellation_token, force_refresh)
   utils.wait_for_schedule_async()
   local session = get_session_async(lsp_client, connection_options)
   utils.safe_assert(session and session.sessionId)
@@ -158,7 +158,8 @@ local get_object_cache_async = function(lsp_client, connection_options, cancella
         clean_up_and_return(nil, "cancelled")
         return
       end
-      lsp_client:request("objectexplorer/expand", {
+      local method = force_refresh and "objectexplorer/refresh" or "objectexplorer/expand"
+      lsp_client:request(method, {
         sessionId = session_id,
         nodePath = path,
       }, function(err, result, _, _)
@@ -330,7 +331,7 @@ local initialise_cache_async = function(lsp_client, connection_options, force)
   local refresh_coroutine = coroutine.running()
   global_cache[key].refresh_coroutine = refresh_coroutine
   vim.cmd("redrawstatus")
-  local new_cache, refresh_error = get_object_cache_async(lsp_client, connection_options, cancellation_token)
+  local new_cache, refresh_error = get_object_cache_async(lsp_client, connection_options, cancellation_token, force)
   if global_cache[key] and global_cache[key].refresh_coroutine == refresh_coroutine then
     global_cache[key].refresh_coroutine = nil
     global_cache[key].cancellation_token = nil

--- a/tests/integration/specs/object_refresh_spec.lua
+++ b/tests/integration/specs/object_refresh_spec.lua
@@ -1,0 +1,239 @@
+local sqlserver = require("sqlserver")
+local integration = require("tests.helpers.integration")
+local utils = require("sqlserver.utils")
+
+local T = MiniTest.new_set()
+
+local function execute(bufnr, text)
+  local execution = integration.await(function(callback)
+    sqlserver.execute({ bufnr = bufnr, text = text }, callback)
+  end)
+  execution.dispose()
+end
+
+local function connect_test_database(bufnr)
+  integration.await(function(callback)
+    sqlserver.disconnect(bufnr, callback)
+  end)
+  integration.connect(bufnr, "TestDbB")
+end
+
+local function list(bufnr, name)
+  return integration.await(function(callback)
+    sqlserver.list_objects({ bufnr = bufnr, name = name, schema = "dbo", type = "Table" }, callback)
+  end)
+end
+
+local function refresh(bufnr)
+  local result = integration.await(function(callback)
+    sqlserver.refresh_objects(bufnr, callback)
+  end)
+  assert(result and result.cancelled == false, "Object refresh did not complete")
+  return result
+end
+
+local function script_definition(bufnr, name)
+  local result
+  local failure
+  sqlserver.script_object(
+    { bufnr = bufnr, name = name, schema = "dbo", type = "Table", intent = "definition" },
+    function(value, err)
+      result = value
+      failure = err
+    end
+  )
+  assert(
+    vim.wait(30000, function()
+      return result ~= nil or failure ~= nil
+    end, 10),
+    "Object scripting did not complete"
+  )
+  return result, failure
+end
+
+T["Refresh replaces created and deleted object metadata"] = require("tests.helpers").async(function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local name = "RefreshCacheProbe"
+  connect_test_database(bufnr)
+
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. ";")
+  refresh(bufnr)
+  assert(#list(bufnr, name) == 0)
+
+  local ok, failure = xpcall(function()
+    execute(bufnr, "CREATE TABLE dbo." .. name .. " (ID int NOT NULL);")
+    assert(#list(bufnr, name) == 0, "Object cache changed without an explicit refresh")
+
+    refresh(bufnr)
+    assert(#list(bufnr, name) == 1, "Created table was absent after refreshing object metadata")
+
+    execute(bufnr, "DROP TABLE dbo." .. name .. ";")
+    assert(#list(bufnr, name) == 1, "Object cache changed without an explicit refresh")
+
+    refresh(bufnr)
+    assert(#list(bufnr, name) == 0, "Dropped table remained after refreshing object metadata")
+  end, debug.traceback)
+
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. ";")
+  assert(ok, failure)
+end, 120000)
+
+T["Object caches remain isolated by database"] = require("tests.helpers").async(function()
+  local database_b_bufnr = vim.api.nvim_get_current_buf()
+  local name = "RefreshIsolationProbe"
+  connect_test_database(database_b_bufnr)
+  execute(database_b_bufnr, "DROP TABLE IF EXISTS dbo." .. name .. "; CREATE TABLE dbo." .. name .. " (ID int);")
+
+  local database_a_bufnr = integration.new_query_buffer()
+  integration.connect(database_a_bufnr, "TestDbA")
+
+  local ok, failure = xpcall(function()
+    refresh(database_b_bufnr)
+    refresh(database_a_bufnr)
+    assert(#list(database_b_bufnr, name) == 1)
+    assert(#list(database_a_bufnr, name) == 0, "TestDbB metadata leaked into the TestDbA cache")
+  end, debug.traceback)
+
+  execute(database_b_bufnr, "DROP TABLE IF EXISTS dbo." .. name .. ";")
+  assert(ok, failure)
+end, 120000)
+
+T["Refresh applies object permission changes"] = require("tests.helpers").async(function()
+  local admin_bufnr = vim.api.nvim_get_current_buf()
+  connect_test_database(admin_bufnr)
+  local restricted_bufnr = integration.new_query_buffer()
+  integration.connect_with(restricted_bufnr, {
+    database = "TestDbB",
+    user = "sqlserver_nvim_restricted",
+    password = "Restricted_Password_123",
+  })
+
+  local function set_permissions(sql)
+    execute(admin_bufnr, sql .. " ON OBJECT::dbo.Car TO sqlserver_nvim_restricted;")
+  end
+
+  local function restore_permissions()
+    set_permissions("GRANT SELECT")
+    set_permissions("GRANT VIEW DEFINITION")
+  end
+
+  restore_permissions()
+  refresh(restricted_bufnr)
+  local ok, failure = xpcall(function()
+    assert(#list(restricted_bufnr, "Car") == 1)
+    local definition, script_error = script_definition(restricted_bufnr, "Car")
+    assert(definition and not script_error)
+
+    set_permissions("DENY SELECT")
+    set_permissions("DENY VIEW DEFINITION")
+    refresh(restricted_bufnr)
+    assert(#list(restricted_bufnr, "Car") == 0, "Revoked object remained visible after refresh")
+
+    set_permissions("GRANT SELECT")
+    set_permissions("GRANT VIEW DEFINITION")
+    refresh(restricted_bufnr)
+    assert(#list(restricted_bufnr, "Car") == 1, "Granted object remained hidden after refresh")
+    definition, script_error = script_definition(restricted_bufnr, "Car")
+    assert(definition and not script_error, "Granted definition remained inaccessible after refresh")
+  end, debug.traceback)
+
+  restore_permissions()
+  assert(ok, failure)
+end, 120000)
+
+T["A newer refresh cancels and replaces an older refresh"] = require("tests.helpers").async(function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  connect_test_database(bufnr)
+  local name = "RefreshOverlapProbe"
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. "; CREATE TABLE dbo." .. name .. " (ID int);")
+
+  local results = {}
+  sqlserver.refresh_objects(bufnr, function(result, err)
+    table.insert(results, { result = result, error = err })
+  end)
+  sqlserver.refresh_objects(bufnr, function(result, err)
+    table.insert(results, { result = result, error = err })
+  end)
+
+  local ok, failure = xpcall(function()
+    assert(
+      vim.wait(30000, function()
+        return #results == 2
+      end, 10),
+      "Overlapping refreshes did not both complete"
+    )
+    assert(not results[1].error and not results[2].error)
+    assert(
+      vim.iter(results):any(function(item)
+        return item.result and item.result.cancelled == true
+      end),
+      "The superseded refresh was not cancelled"
+    )
+    assert(
+      vim.iter(results):any(function(item)
+        return item.result and item.result.cancelled == false
+      end),
+      "The newest refresh did not complete"
+    )
+    assert(#list(bufnr, name) == 1, "The newest refresh did not replace the cache")
+  end, debug.traceback)
+
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. ";")
+  assert(ok, failure)
+end, 120000)
+
+T["A failed refresh retains the previous object cache"] = require("tests.helpers").async(function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  connect_test_database(bufnr)
+  local picker = require("sqlserver.objects.ui.picker")
+  assert(#list(bufnr, "Car") == 1)
+
+  picker.setup({ object_explorer = 1 })
+  local _, refresh_error
+  sqlserver.refresh_objects(bufnr, function(_, err)
+    refresh_error = err
+  end)
+  assert(
+    vim.wait(30000, function()
+      return refresh_error ~= nil
+    end, 10),
+    "Deliberately timed-out refresh did not fail"
+  )
+  picker.setup({ object_explorer = 10000 })
+
+  assert(#list(bufnr, "Car") == 1, "A failed refresh discarded the previous object cache")
+end, 120000)
+
+T["Refresh cache updates objects and IntelliSense"] = require("tests.helpers").async(function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  connect_test_database(bufnr)
+  local client = integration.get_sql_client(bufnr)
+  local name = "RefreshIntelliSenseProbe"
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. "; CREATE TABLE dbo." .. name .. " (ID int);")
+
+  local ready
+  local ready_error
+  integration.wait_for_all_async({
+    function()
+      ready, ready_error = utils.wait_for_notification_async(bufnr, client, "textDocument/intelliSenseReady", 30000)
+    end,
+    function()
+      sqlserver.refresh_cache()
+    end,
+  })
+
+  local ok, failure = xpcall(function()
+    assert(ready and not ready_error, ready_error and ready_error.message)
+    assert(
+      vim.wait(30000, function()
+        return #list(bufnr, name) == 1
+      end, 10),
+      "refresh_cache did not replace object metadata"
+    )
+  end, debug.traceback)
+
+  execute(bufnr, "DROP TABLE IF EXISTS dbo." .. name .. ";")
+  assert(ok, failure)
+end, 120000)
+
+return T

--- a/tests/integration/test_integration.lua
+++ b/tests/integration/test_integration.lua
@@ -46,6 +46,7 @@ for _, module in ipairs({
   "query_error_presentation_spec",
   "finder_spec",
   "object_scripting_spec",
+  "object_refresh_spec",
   "query_zero_rows_spec",
   "file_with_space_spec",
   "non_ascii_spec",


### PR DESCRIPTION
## Proposed changes

Use the SQL Tools Service Object Explorer refresh request for forced metadata rebuilds instead of expanding the existing explorer session. This ensures explicit refreshes retrieve current schema and permission information from SQL Server rather than retaining stale service state.

Cover object creation and deletion, database cache isolation, permission changes, concurrent refreshes, failed-refresh cache retention, and the combined metadata and IntelliSense refresh workflow with Docker-backed integration tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring or internal improvement
- [ ] Documentation

## Checklist

- [x] I have read the [contributing guide](https://github.com/NicholasMata/sqlserver.nvim/blob/main/CONTRIBUTING.md).
- [x] This pull request contains one coherent change.
- [x] I have added or updated relevant tests, or explained why none are needed.
- [x] I have updated relevant documentation, or none is needed.
- [x] I have updated the Unreleased changelog, or the change is not user-visible.
- [x] I have not included credentials or private database contents.

## Further context

This pull request is stacked on #1 because its permission-refresh coverage reuses the restricted-login integration fixture introduced there. Its diff contains only metadata-refresh behavior and tests. After #1 merges, this pull request should target `main`.

A failed refresh preserves the last successful cache instead of replacing it with incomplete state.