### PR TITLE
Shard database integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,8 +171,12 @@ jobs:
           }
 
   integration-linux:
-    name: Database integration tests (ubuntu-latest)
+    name: Database integration tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, objects]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -190,13 +194,13 @@ jobs:
         run: make test-env-seed
 
       - name: Run integration tests with coverage
-        run: make coverage-clean coverage-run-integration
+        run: make coverage-clean coverage-run-integration-shard SHARD=${{ matrix.shard }}
 
       - name: Upload coverage statistics
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-stats-integration-${{ runner.os }}-${{ runner.arch }}
+          name: coverage-stats-integration-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}
           path: coverage/luacov.stats.out
           if-no-files-found: error
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ per-file and overall summary to `coverage/summary.txt`. Coverage runs disable
 LuaJIT so LuaCov can observe executed lines reliably. Coverage is diagnostic;
 the project does not currently enforce a minimum percentage. CI merges raw
 coverage statistics from Linux, macOS, Windows, and the Docker integration
-suite so platform-specific branches are represented in one report.
+suite so platform-specific branches are represented in one report. The Docker
+suite runs as isolated `core` and `objects` jobs in CI; each job starts and
+seeds its own SQL Server container and uploads a uniquely named coverage shard.
 
 ## Integration tests
 
@@ -78,6 +80,17 @@ make test-integration-local
 This requires Docker with the Compose plugin. The target starts SQL Server,
 waits for it to become healthy, recreates fixture databases, downloads SQL
 Tools Service into `.tests/`, and runs the integration suite.
+
+The local commands remain unsharded. To reproduce one CI shard against an
+already seeded test environment, run either:
+
+```sh
+make test-integration-shard SHARD=core
+make test-integration-shard SHARD=objects
+```
+
+Every integration spec is assigned to exactly one shard. A unit test fails when
+a spec is unassigned, assigned more than once, or no longer exists.
 
 Stop and remove the test database and its volumes with:
 

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ export SQLSERVER_PORT ?= 1433
 .NOTPARALLEL: test-all test-integration-local coverage coverage-unit coverage-platform coverage-integration
 
 .PHONY: format format-check lint lint-doc-filenames
-.PHONY: test test-deps test-unit test-platform test-integration test-integration-local test-all assert-no-process-leaks
+.PHONY: test test-deps test-unit test-platform test-integration test-integration-shard test-integration-local test-all assert-no-process-leaks
 .PHONY: test-env-up test-env-seed test-env-reset test-env-down
 .PHONY: coverage coverage-clean coverage-deps coverage-unit coverage-platform coverage-integration coverage-report
-.PHONY: coverage-run-unit coverage-run-platform coverage-run-integration
+.PHONY: coverage-run-unit coverage-run-platform coverage-run-integration coverage-run-integration-shard
 
 test: test-unit
 
@@ -68,6 +68,12 @@ test-integration: test-deps
 		$(NVIM) --headless --clean -u tests/minimal-init.lua -c "lua MiniTest.run()"
 	$(MAKE) assert-no-process-leaks
 
+test-integration-shard: test-deps
+	@test -n "$(SHARD)" || { printf 'SHARD is required (core or objects)\n' >&2; exit 1; }
+	$(TEST_ENV) SQLSERVER_TEST_SUITE=integration SQLSERVER_INTEGRATION_SHARD=$(SHARD) \
+		$(NVIM) --headless --clean -u tests/minimal-init.lua -c "lua MiniTest.run()"
+	$(MAKE) assert-no-process-leaks
+
 test-integration-local: test-env-seed test-integration
 
 test-all: test-unit test-platform test-integration-local
@@ -88,6 +94,13 @@ coverage-run-platform: coverage-deps
 
 coverage-run-integration: coverage-deps
 	$(TEST_ENV) SQLSERVER_TEST_SUITE=integration SQLSERVER_COVERAGE=1 \
+		LUACOV_CONFIG=$(CURDIR)/.luacov \
+		$(NVIM) --headless --clean -u tests/minimal-init.lua -c "lua MiniTest.run()"
+	$(MAKE) assert-no-process-leaks
+
+coverage-run-integration-shard: coverage-deps
+	@test -n "$(SHARD)" || { printf 'SHARD is required (core or objects)\n' >&2; exit 1; }
+	$(TEST_ENV) SQLSERVER_TEST_SUITE=integration SQLSERVER_INTEGRATION_SHARD=$(SHARD) SQLSERVER_COVERAGE=1 \
 		LUACOV_CONFIG=$(CURDIR)/.luacov \
 		$(NVIM) --headless --clean -u tests/minimal-init.lua -c "lua MiniTest.run()"
 	$(MAKE) assert-no-process-leaks

--- a/tests/integration/shards.lua
+++ b/tests/integration/shards.lua
@@ -1,0 +1,58 @@
+local M = {}
+
+M.environment = {
+  core = {
+    "saved_file_completion_spec",
+    "edit_connections_spec",
+    "new_query_completion_spec",
+    "connect_spec",
+    "unnamed_query_buffer_spec",
+  },
+  objects = {},
+}
+
+M.connected = {
+  core = {
+    "public_api_integration_spec",
+    "execution_scope_integration_spec",
+    "error_line_numbers_integration_spec",
+    "execute_query_spec",
+    "multiple_result_sets_spec",
+    "result_history_integration_spec",
+    "mixed_query_results_spec",
+    "failed_statement_results_spec",
+    "result_value_fidelity_spec",
+    "result_limits_spec",
+    "query_error_presentation_spec",
+    "query_zero_rows_spec",
+    "file_with_space_spec",
+    "non_ascii_spec",
+    "cancel_query_spec",
+  },
+  objects = {
+    "dbo_completion_spec",
+    "switch_database_spec",
+    "language_intelligence_spec",
+    "finder_spec",
+    "object_scripting_spec",
+    "object_refresh_spec",
+    "use_query_spec",
+  },
+}
+
+M.names = { "core", "objects" }
+
+function M.modules(group, shard)
+  local groups = assert(M[group], "Unknown integration test group: " .. tostring(group))
+  if shard and shard ~= "" then
+    return assert(groups[shard], "Unknown integration test shard: " .. shard)
+  end
+
+  local modules = {}
+  for _, name in ipairs(M.names) do
+    vim.list_extend(modules, groups[name])
+  end
+  return modules
+end
+
+return M

--- a/tests/integration/test_integration.lua
+++ b/tests/integration/test_integration.lua
@@ -1,5 +1,7 @@
 local helpers = require("tests.helpers")
 local integration = require("tests.helpers.integration")
+local shards = require("tests.integration.shards")
+local shard = vim.env.SQLSERVER_INTEGRATION_SHARD
 
 local T = MiniTest.new_set({
   hooks = {
@@ -18,41 +20,12 @@ local T = MiniTest.new_set({
 T["environment"] = MiniTest.new_set({
   hooks = { post_case = helpers.async(integration.cleanup) },
 })
-for _, module in ipairs({
-  "saved_file_completion_spec",
-  "edit_connections_spec",
-  "new_query_completion_spec",
-  "connect_spec",
-  "unnamed_query_buffer_spec",
-}) do
+for _, module in ipairs(shards.modules("environment", shard)) do
   T["environment"][module] = require("tests.integration.specs." .. module)
 end
 
 T["connected workspace"] = MiniTest.new_set({ hooks = integration.connected_hooks() })
-for _, module in ipairs({
-  "dbo_completion_spec",
-  "public_api_integration_spec",
-  "execution_scope_integration_spec",
-  "error_line_numbers_integration_spec",
-  "execute_query_spec",
-  "multiple_result_sets_spec",
-  "result_history_integration_spec",
-  "mixed_query_results_spec",
-  "failed_statement_results_spec",
-  "switch_database_spec",
-  "language_intelligence_spec",
-  "result_value_fidelity_spec",
-  "result_limits_spec",
-  "query_error_presentation_spec",
-  "finder_spec",
-  "object_scripting_spec",
-  "object_refresh_spec",
-  "query_zero_rows_spec",
-  "file_with_space_spec",
-  "non_ascii_spec",
-  "cancel_query_spec",
-  "use_query_spec",
-}) do
+for _, module in ipairs(shards.modules("connected", shard)) do
   T["connected workspace"][module] = require("tests.integration.specs." .. module)
 end
 

--- a/tests/unit/integration_shards_spec.lua
+++ b/tests/unit/integration_shards_spec.lua
@@ -1,0 +1,37 @@
+local shards = require("tests.integration.shards")
+
+local T = MiniTest.new_set()
+
+local function assigned_modules()
+  local assigned = {}
+  for _, group in ipairs({ "environment", "connected" }) do
+    for _, module in ipairs(shards.modules(group)) do
+      assert(not assigned[module], "Integration spec assigned more than once: " .. module)
+      assigned[module] = true
+    end
+  end
+  return assigned
+end
+
+T["Integration shards assign every spec exactly once"] = function()
+  local assigned = assigned_modules()
+  local specs = vim.fs.joinpath(vim.fn.getcwd(), "tests", "integration", "specs")
+
+  for filename, file_type in vim.fs.dir(specs) do
+    if file_type == "file" and filename:match("_spec%.lua$") then
+      local module = filename:gsub("%.lua$", "")
+      assert(assigned[module], "Integration spec is not assigned to a shard: " .. module)
+      assigned[module] = nil
+    end
+  end
+
+  assert(next(assigned) == nil, "Integration shard references a missing spec: " .. tostring(next(assigned)))
+end
+
+T["Integration shards reject unknown names"] = function()
+  local ok, err = pcall(shards.modules, "connected", "missing")
+  assert(not ok)
+  assert(tostring(err):find("Unknown integration test shard: missing", 1, true))
+end
+
+return T

--- a/tests/unit/test_unit.lua
+++ b/tests/unit/test_unit.lua
@@ -27,6 +27,7 @@ local modules = {
   "sql_tools_service_scripting_spec",
   "query_summary_spec",
   "object_script_spec",
+  "integration_shards_spec",
 }
 
 for _, module in ipairs(modules) do


### PR DESCRIPTION
## Proposed changes

Run the Docker-backed integration suite as parallel `core` and `objects` jobs. Each matrix job receives an isolated GitHub runner, starts and seeds its own SQL Server container, performs its own process-leak assertions, and uploads a uniquely named coverage artifact.

Centralize integration spec membership in a shard manifest and add unit coverage that rejects missing, duplicate, and stale assignments. Preserve the existing unsharded local integration command while adding explicit commands for reproducing either CI shard.

This reduces the database integration critical path without allowing schema or permission mutations to cross shard boundaries.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring or internal improvement
- [x] Documentation

## Checklist

- [x] I have read the [contributing guide](https://github.com/NicholasMata/sqlserver.nvim/blob/main/CONTRIBUTING.md).
- [x] This pull request contains one coherent change.
- [x] I have added or updated relevant tests, or explained why none are needed.
- [x] I have updated relevant documentation, or none is needed.
- [x] I have updated the Unreleased changelog, or the change is not user-visible.
- [x] I have not included credentials or private database contents.

## Further context

The existing coverage merger already discovers every `luacov.stats.out` beneath the downloaded artifact directory, so uniquely named shard artifacts continue to produce one combined report.

This pull request is independent of the CI setup optimization. If that pull request merges first, this branch should be rebased onto `main` before merging so the combined workflow receives a final CI pass.