### PR TITLE
Reduce redundant CI setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,60 @@ env:
   NVIM_VERSION: v0.11.7
 
 jobs:
-  unit-unix:
-    name: Unit and platform tests (${{ matrix.os }})
+  lint:
+    name: Lint (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install StyLua 2.5.2
+        run: |
+          curl -fsSL "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.5.2/stylua-linux-x86_64.zip" \
+            -o "$RUNNER_TEMP/stylua-linux-x86_64.zip"
+          echo "bcb0d855e91f102f28a370e850f8566b3b44b79e6274d806ea5246837c0fd5ab  $RUNNER_TEMP/stylua-linux-x86_64.zip" \
+            | sha256sum --check
+          unzip -q "$RUNNER_TEMP/stylua-linux-x86_64.zip" -d "$RUNNER_TEMP/stylua"
+          echo "$RUNNER_TEMP/stylua" >> "$GITHUB_PATH"
+
+      - name: Check formatting and documentation filenames
+        run: make lint
+
+  unit-linux:
+    name: Unit tests (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Neovim 0.11.7
+        run: |
+          curl -fsSL "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.tar.gz" \
+            -o "$RUNNER_TEMP/nvim-linux-x86_64.tar.gz"
+          mkdir -p "$RUNNER_TEMP/neovim"
+          tar -xzf "$RUNNER_TEMP/nvim-linux-x86_64.tar.gz" -C "$RUNNER_TEMP/neovim" --strip-components=1
+          echo "$RUNNER_TEMP/neovim/bin" >> "$GITHUB_PATH"
+
+      - name: Run unit tests with coverage
+        run: make coverage-clean coverage-run-unit
+
+      - name: Upload coverage statistics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-stats-unit-${{ runner.os }}-${{ runner.arch }}
+          path: coverage/luacov.stats.out
+          if-no-files-found: error
+
+      - name: Assert clean repository
+        run: test -z "$(git status --porcelain --untracked-files=all)"
+
+  platform-unix:
+    name: Platform tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -30,9 +82,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Install StyLua
-        run: cargo install stylua --version 2.5.2 --locked
 
       - name: Install Neovim 0.11.7
         run: |
@@ -49,14 +98,8 @@ jobs:
           tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/neovim" --strip-components=1
           echo "$RUNNER_TEMP/neovim/bin" >> "$GITHUB_PATH"
 
-      - name: Check formatting
-        run: make lint
-
-      - name: Run unit tests with coverage
-        run: make coverage-clean coverage-run-unit
-
       - name: Run platform integration tests with coverage
-        run: make coverage-run-platform
+        run: make coverage-clean coverage-run-platform
 
       - name: Upload coverage statistics
         if: always()
@@ -69,17 +112,14 @@ jobs:
       - name: Assert clean repository
         run: test -z "$(git status --porcelain --untracked-files=all)"
 
-  unit-windows:
-    name: Unit and platform tests (windows-latest)
+  platform-windows:
+    name: Platform tests (windows-latest)
     runs-on: windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Install StyLua
-        run: cargo install stylua --version 2.5.2 --locked
 
       - name: Install Neovim 0.11.7
         shell: pwsh
@@ -89,19 +129,7 @@ jobs:
           Expand-Archive $archive "$env:RUNNER_TEMP\neovim"
           "$env:RUNNER_TEMP\neovim\nvim-win64\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
-      - name: Check formatting
-        run: stylua --check lua ftplugin tests scripts
-
-      - name: Check documentation filenames
-        shell: pwsh
-        run: |
-          $invalid = Get-ChildItem docs -Recurse -File | Where-Object { $_.Name -cnotmatch '^[a-z0-9]+(-[a-z0-9]+)*\.[a-z0-9]+$' }
-          if ($invalid) {
-            $invalid.FullName
-            throw "Documentation filenames must use lowercase kebab-case"
-          }
-
-      - name: Run unit tests
+      - name: Install test dependencies
         shell: pwsh
         run: |
           $root = "$env:GITHUB_WORKSPACE\.tests"
@@ -113,18 +141,15 @@ jobs:
           git clone --filter=blob:none https://github.com/lunarmodules/luacov.git $luacov
           git -C $luacov checkout b1f9eae400da976b93edb7f94cf5d05f538a0655
           New-Item -ItemType Directory -Force "$env:GITHUB_WORKSPACE\coverage" | Out-Null
-          $env:XDG_CONFIG_HOME = "$root\config"
-          $env:XDG_DATA_HOME = "$root\data"
-          $env:XDG_STATE_HOME = "$root\state"
-          $env:XDG_CACHE_HOME = "$root\cache"
-          $env:SQLSERVER_TEST_SUITE = "unit"
-          $env:SQLSERVER_COVERAGE = "1"
-          $env:LUACOV_CONFIG = "$env:GITHUB_WORKSPACE\.luacov"
-          nvim --headless --clean -u tests/minimal-init.lua -c "lua MiniTest.run()"
 
       - name: Run platform integration tests with coverage
         shell: pwsh
         run: |
+          $root = "$env:GITHUB_WORKSPACE\.tests"
+          $env:XDG_CONFIG_HOME = "$root\config"
+          $env:XDG_DATA_HOME = "$root\data"
+          $env:XDG_STATE_HOME = "$root\state"
+          $env:XDG_CACHE_HOME = "$root\cache"
           $env:SQLSERVER_TEST_SUITE = "platform"
           $env:SQLSERVER_COVERAGE = "1"
           $env:LUACOV_CONFIG = "$env:GITHUB_WORKSPACE\.luacov"
@@ -189,7 +214,7 @@ jobs:
 
   coverage-report:
     name: Combined coverage report
-    needs: [unit-unix, unit-windows, integration-linux]
+    needs: [unit-linux, platform-unix, platform-windows, integration-linux]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Proposed changes

Run formatting and documentation filename checks once in a dedicated Ubuntu lint job. Install the pinned official StyLua 2.5.2 release binary and verify its published SHA-256 digest instead of compiling StyLua with Cargo on every operating system.

Run ordinary unit coverage once on Ubuntu while retaining native SQL Tools Service installation and lifecycle coverage on Linux, macOS, and Windows. Update coverage job dependencies and artifact names so the combined report still includes unit, native platform, and database execution.

This removes repeated setup and test work from the platform jobs without reducing the platform-specific behavior they verify.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring or internal improvement
- [ ] Documentation

## Checklist

- [x] I have read the [contributing guide](https://github.com/NicholasMata/sqlserver.nvim/blob/main/CONTRIBUTING.md).
- [x] This pull request contains one coherent change.
- [x] I have added or updated relevant tests, or explained why none are needed.
- [x] I have updated relevant documentation, or none is needed.
- [x] I have updated the Unreleased changelog, or the change is not user-visible.
- [x] I have not included credentials or private database contents.

## Further context

The StyLua archive comes directly from the official release and is checked against the SHA-256 digest published in that release metadata. No additional third-party GitHub Action is introduced.

Fresh SQL Tools Service installation remains intentionally uncached because downloading and extracting the managed service is part of the native platform test.